### PR TITLE
Remove hard coded repo name

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/robot-cow-bot:latest
+          tags: ghcr.io/${{ github.repository }}:latest
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: |
+          echo "🎉 You can now pull this image using the below commands:"
+          echo "docker pull ghcr.io/${{ github.repository }}@${{ steps.docker_build.outputs.digest }}"
+          echo "docker pull ghcr.io/${{ github.repository }}:latest"


### PR DESCRIPTION
This will enable our CI script to be independent of the repository name.

Successful sample run: https://github.com/ahhda/robot-cow-bot/actions/runs/2350369405